### PR TITLE
Update gemspec dependencies and license

### DIFF
--- a/swiftype-app-search.gemspec
+++ b/swiftype-app-search.gemspec
@@ -9,15 +9,16 @@ Gem::Specification.new do |s|
   s.homepage    = "https://swiftype.com"
   s.summary     = %q{Official gem for accessing the Swiftype App Search API}
   s.description = %q{API client for accessing the Swiftype App Search API with no dependencies.}
+  s.licenses    = ['MIT']
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'rspec', '~> 3.0.0'
-  s.add_development_dependency 'awesome_print'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'awesome_print', '~> 1.8'
+  s.add_development_dependency 'webmock', '~> 3.3'
 
-  s.add_runtime_dependency 'jwt', '~> 1.5.1'
+  s.add_runtime_dependency 'jwt', '~> 1.5'
 end


### PR DESCRIPTION
`gem build` complained about our pessimistic deps, open-ended deps, and
the lack of a license.