### PR TITLE
Resolve issue handling unexpected HTTP errors

### DIFF
--- a/lib/swiftype-app-search/exceptions.rb
+++ b/lib/swiftype-app-search/exceptions.rb
@@ -3,7 +3,7 @@ module SwiftypeAppSearch
     attr_reader :errors
 
     def initialize(response)
-      @errors = response['errors'] || [ response ]
+      @errors = response['errors'] || [response]
       message = (errors.count == 1) ? "Error: #{errors.first}" : "Errors: #{errors.inspect}"
       super(message)
     end
@@ -16,9 +16,10 @@ module SwiftypeAppSearch
   class InvalidDocument < ClientException; end
 
   class UnexpectedHTTPException < ClientException
-    def initialize(http_response)
-      @errors = []
-      super("HTTP #{http_response.code}: #{http_response.body}")
+    def initialize(response, response_body)
+      response_body['errors'] = [response.message] unless response_body['errors']
+      response_body['errors'].map! { |e| "(#{response.code}) #{e}" }
+      super(response_body)
     end
   end
 end

--- a/lib/swiftype-app-search/request.rb
+++ b/lib/swiftype-app-search/request.rb
@@ -68,7 +68,7 @@ module SwiftypeAppSearch
         when Net::HTTPForbidden
           raise SwiftypeAppSearch::Forbidden, response_json
         else
-          raise SwiftypeAppSearch::UnexpectedHTTPException, response
+          raise SwiftypeAppSearch::UnexpectedHTTPException.new(response, response_json)
         end
       end
     end


### PR DESCRIPTION
This fixes #4.

I was receiving a generic error when surpassing the limit of 100 documents per request. 
```ruby
ArgumentError: wrong number of arguments (given 0, expected 1+)
```

After digging into the issue I realized I was actually receiving a `Net::HTTPRequestEntityTooLarge` but it was being incorrectly handled by the `SwiftypeAppSearch::UnexpectedHTTPException`

The problem was on this line in `SwiftypeAppSearch::ClientException`
```ruby
message = (errors.count == 1) ? "Error: #{errors.first}" : "Errors: #{errors.inspect}"
*** ArgumentError Exception: wrong number of arguments (given 0, expected 1+)
```

This fix ensures that the response is formatted as the `SwiftypeAppSearch::ClientException` expects. It produces errors that include HTTP response codes and a relevant error message.

If the response body contains an 'errors' key, the response looks like:
```ruby
SwiftypeAppSearch::UnexpectedHTTPException: Error: (413) Request exceeds maximum allowed limit of  documents
```

If the response body contains no 'errors' key, it uses the response message as the error
```ruby
SwiftypeAppSearch::UnexpectedHTTPException: Error: (413) Payload Too Large
```