### PR TITLE
Added error type RequestEntityTooLarge

### DIFF
--- a/lib/swiftype-app-search/exceptions.rb
+++ b/lib/swiftype-app-search/exceptions.rb
@@ -14,6 +14,7 @@ module SwiftypeAppSearch
   class BadRequest < ClientException; end
   class Forbidden < ClientException; end
   class InvalidDocument < ClientException; end
+  class RequestEntityTooLarge < ClientException; end
 
   class UnexpectedHTTPException < ClientException
     def initialize(http_response)

--- a/lib/swiftype-app-search/request.rb
+++ b/lib/swiftype-app-search/request.rb
@@ -67,6 +67,8 @@ module SwiftypeAppSearch
           raise SwiftypeAppSearch::NonExistentRecord, response_json
         when Net::HTTPForbidden
           raise SwiftypeAppSearch::Forbidden, response_json
+        when Net::HTTPRequestEntityTooLarge
+          raise SwiftypeAppSearch::RequestEntityTooLarge, response_json
         else
           raise SwiftypeAppSearch::UnexpectedHTTPException, response
         end


### PR DESCRIPTION
Relates to #4.

It may be nice to have a specific error class within the gem given that the API returns this error when the maximum number of documents are sent.

Technically the fix in #5 covers this error case though :) 