### PR TITLE
Serialize Date/Time Ruby objects in RFC 3339

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,15 @@ end
 ```bash
 export AS_API_KEY="your API key"
 export AS_ACCOUNT_HOST_KEY="your account host key"
-rspec
+bundle exec rspec
+```
+
+You can also run tests against a local environment by passing a `AS_API_ENDPOINT` environment variable
+
+```bash
+export AS_API_KEY="your API key"
+export AS_API__ENDPOINT="http://<your account host key>.api.127.0.0.1.ip.es.io:3002/api/as/v1"
+bundle exec rspec
 ```
 
 ## Debugging API calls

--- a/lib/swiftype-app-search/request.rb
+++ b/lib/swiftype-app-search/request.rb
@@ -94,7 +94,10 @@ module SwiftypeAppSearch
     def clean_json(object)
       case object
       when Hash
-        object.transform_values { |value| clean_json(value) }
+        object.inject({}) do |builder, (key, value)|
+          builder[key] = clean_json(value)
+          builder
+        end
       when Enumerable
         object.map { |value| clean_json(value) }
       else
@@ -103,9 +106,8 @@ module SwiftypeAppSearch
     end
 
     def clean_atom(atom)
-      case atom
-      when Time, DateTime
-        atom.iso8601
+      if atom.is_a?(Time)
+        atom.to_datetime
       else
         atom
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -42,18 +42,18 @@ describe SwiftypeAppSearch::Client do
       end
 
       context 'when a document has a Ruby Time object' do
-        let(:time_iso8601) { '2018-01-01T01:01:01Z' }
-        let(:time_object) { Time.parse(time_iso8601) }
+        let(:time_rfc3339) { '2018-01-01T01:01:01+00:00' }
+        let(:time_object) { Time.parse(time_rfc3339) }
         let(:document) { { 'created_at' => time_object } }
 
-        it 'should serialize the time object in ISO 8601' do
+        it 'should serialize the time object in RFC 3339' do
           response = subject
           expect(response).to have_key('id')
           document_id = response.fetch('id')
           expect do
             documents = client.get_documents(engine_name, [document_id])
             expect(documents.size).to eq(1)
-            expect(documents.first['created_at']).to eq(time_iso8601)
+            expect(documents.first['created_at']).to eq(time_rfc3339)
           end.to_not raise_error
         end
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,7 +2,7 @@ describe SwiftypeAppSearch::Client do
   let(:engine_name) { "ruby-client-test-#{Time.now.to_i}" }
 
   include_context "App Search Credentials"
-  let(:client) { SwiftypeAppSearch::Client.new(:account_host_key => as_account_host_key, :api_key => as_api_key) }
+  let(:client) { SwiftypeAppSearch::Client.new(client_options) }
 
   context 'Documents' do
     let(:document) { { 'url' => 'http://www.youtube.com/watch?v=v1uyQZNg2vE' } }
@@ -38,6 +38,23 @@ describe SwiftypeAppSearch::Client do
           expect do
             subject
           end.to raise_error(SwiftypeAppSearch::InvalidDocument, /Invalid field/)
+        end
+      end
+
+      context 'when a document has a Ruby Time object' do
+        let(:time_iso8601) { '2018-01-01T01:01:01Z' }
+        let(:time_object) { Time.parse(time_iso8601) }
+        let(:document) { { 'created_at' => time_object } }
+
+        it 'should serialize the time object in ISO 8601' do
+          response = subject
+          expect(response).to have_key('id')
+          document_id = response.fetch('id')
+          expect do
+            documents = client.get_documents(engine_name, [document_id])
+            expect(documents.size).to eq(1)
+            expect(documents.first['created_at']).to eq(time_iso8601)
+          end.to_not raise_error
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,15 @@ require 'swiftype-app-search'
 RSpec.shared_context "App Search Credentials" do
   let(:as_api_key) { ENV.fetch('AS_API_KEY', 'API_KEY') }
   let(:as_account_host_key) { ENV.fetch('AS_ACCOUNT_HOST_KEY', 'ACCOUNT_HOST_KEY') }
+  let(:as_api_endpoint) { ENV.fetch('AS_API_ENDPOINT', nil) }
+  let(:client_options) do
+    {
+      :api_key => as_api_key,
+      :account_host_key => as_account_host_key
+    }.tap do |opts|
+      opts[:api_endpoint] = as_api_endpoint unless as_api_endpoint.nil?
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/swiftype-app-search.gemspec
+++ b/swiftype-app-search.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'awesome_print', '~> 1.8'
+  s.add_development_dependency 'pry', '~> 0.11.3'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 3.3'
 
   s.add_runtime_dependency 'jwt', '~> 2.1'


### PR DESCRIPTION
This addresses issues where `JSON.generate(...)` would not serialize Ruby DateTime or Time objects in ISO 8601 format.

I've also added `pry` as a development dependency and allowed configuring an `:api_endpoint` option in specs, to allow running the client against a local development environment.