### PR TITLE
Modified parameter name fallback logic  and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,16 +173,16 @@ end
 ## Running Tests
 
 ```bash
-export PRIVATE_KEY="[AS_API_KEY]"
-export HOST_IDENTIFIER="[AS_HOST_IDENTIFIER]"
+export AS_API_KEY="[API_KEY]"
+export AS_HOST_IDENTIFIER="[HOST_IDENTIFIER]"
 bundle exec rspec
 ```
 
 You can also run tests against a local environment by passing a `AS_API_ENDPOINT` environment variable
 
 ```bash
-export API_KEY="[AS_API_KEY]"
-export API_ENDPOINT="http://[AS_HOST_IDENTIFIER].api.127.0.0.1.ip.es.io:3002/api/as/v1"
+export AS_API_KEY="[API_KEY]"
+export AS_API_ENDPOINT="http://[HOST_IDENTIFIER].api.127.0.0.1.ip.es.io:3002/api/as/v1"
 bundle exec rspec
 ```
 

--- a/lib/swiftype-app-search/client.rb
+++ b/lib/swiftype-app-search/client.rb
@@ -25,7 +25,7 @@ module SwiftypeAppSearch
     # @option options [Numeric] :open_timeout the number of seconds Net::HTTP (default: 15s)
     #   will wait while opening a connection before raising a Timeout::Error
     def initialize(options = {})
-      @api_endpoint = options.fetch(:api_endpoint) { "https://#{options.fetch(:account_host_key) || options.fetch(:host_identifier)}.api.swiftype.com/api/as/v1/" }
+      @api_endpoint = options.fetch(:api_endpoint) { "https://#{options.fetch(:account_host_key) { options.fetch(:host_identifier) }}.api.swiftype.com/api/as/v1/" }
       @api_key = options.fetch(:api_key)
       @open_timeout = options.fetch(:open_timeout, DEFAULT_TIMEOUT).to_f
       @overall_timeout = options.fetch(:overall_timeout, DEFAULT_TIMEOUT).to_f

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -148,8 +148,13 @@ describe SwiftypeAppSearch::Client do
   end
 
   context 'Configuration' do
-    context 'account_host_key' do
+    context 'host_identifier' do
       it 'sets the base url correctly' do
+        client = SwiftypeAppSearch::Client.new(:host_identifier => 'host-asdf', :api_key => 'foo')
+        expect(client.api_endpoint).to eq('https://host-asdf.api.swiftype.com/api/as/v1/')
+      end
+
+      it 'sets the base url correctly using deprecated as_host_key' do
         client = SwiftypeAppSearch::Client.new(:account_host_key => 'host-asdf', :api_key => 'foo')
         expect(client.api_endpoint).to eq('https://host-asdf.api.swiftype.com/api/as/v1/')
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,13 @@ require 'swiftype-app-search'
 
 RSpec.shared_context "App Search Credentials" do
   let(:as_api_key) { ENV.fetch('AS_API_KEY', 'API_KEY') }
-  let(:as_account_host_key) { ENV['AS_ACCOUNT_HOST_KEY'] || ENV['AS_HOST_IDENTIFIER'] || 'ACCOUNT_HOST_KEY' }
+  # AS_ACCOUNT_HOST_KEY is deprecated
+  let(:as_host_identifier) { ENV['AS_ACCOUNT_HOST_KEY'] || ENV['AS_HOST_IDENTIFIER'] || 'ACCOUNT_HOST_KEY' }
   let(:as_api_endpoint) { ENV.fetch('AS_API_ENDPOINT', nil) }
   let(:client_options) do
     {
       :api_key => as_api_key,
-      :account_host_key => as_account_host_key
+      :host_identifier => as_host_identifier
     }.tap do |opts|
       opts[:api_endpoint] = as_api_endpoint unless as_api_endpoint.nil?
     end


### PR DESCRIPTION
- PRIVATE_KEY and API_KEY were both used
- exports in README did not work
- fallback logic wasn't working, client was not instantiated unless :account_host_key was provided

Should be all squared away now!