### PR TITLE
Updated reporting headers

### DIFF
--- a/lib/swiftype-app-search/request.rb
+++ b/lib/swiftype-app-search/request.rb
@@ -6,7 +6,8 @@ require 'swiftype-app-search/version'
 require 'openssl'
 
 module SwiftypeAppSearch
-  DEFAULT_USER_AGENT = "swiftype-app-search-ruby/#{SwiftypeAppSearch::VERSION}"
+  CLIENT_NAME = 'swiftype-app-search-ruby'
+  CLIENT_VERSION = SwiftypeAppSearch::VERSION
 
   module Request
     attr_accessor :last_request
@@ -133,7 +134,8 @@ module SwiftypeAppSearch
       req = klass.new(uri.request_uri)
       req.body = serialize_json(params) unless params.length == 0
 
-      req['User-Agent'] = DEFAULT_USER_AGENT
+      req['X-Swiftype-Client'] = CLIENT_NAME
+      req['X-Swiftype-Client-Version'] = CLIENT_VERSION
       req['Content-Type'] = 'application/json'
       req['Authorization'] = "Bearer #{api_key}"
 

--- a/lib/swiftype-app-search/version.rb
+++ b/lib/swiftype-app-search/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeAppSearch
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,8 +1,23 @@
+
 describe SwiftypeAppSearch::Client do
   let(:engine_name) { "ruby-client-test-#{Time.now.to_i}" }
 
   include_context "App Search Credentials"
   let(:client) { SwiftypeAppSearch::Client.new(client_options) }
+
+  describe 'Requests' do
+    it 'should include client name and version in headers' do
+      stub_request(:any, "#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines")
+      client.list_engines
+      expect(WebMock).to have_requested(:get, "https://#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines").
+        with(
+          headers: {
+            'X-Swiftype-Client' => 'swiftype-app-search-ruby',
+            'X-Swiftype-Client-Version' => SwiftypeAppSearch::VERSION
+          }
+        )
+    end
+  end
 
   context 'Documents' do
     let(:document) { { 'url' => 'http://www.youtube.com/watch?v=v1uyQZNg2vE' } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 require 'bundler/setup'
 require 'rspec'
-require 'webmock'
+require 'webmock/rspec'
 require 'awesome_print'
 require 'swiftype-app-search'
+
+WebMock.allow_net_connect!
 
 RSpec.shared_context "App Search Credentials" do
   let(:as_api_key) { ENV.fetch('AS_API_KEY', 'API_KEY') }


### PR DESCRIPTION
[ENG-1107] Clients should send a header with Client type and version

Fixes #22

This lets us more accurately report on client type and version. It also
keeps the User-Agent header free for whatever the platforms
natural User-Agent value is.