### PR TITLE
Backfilled Engine, Document, and Search APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,10 @@ document = {
   :body => 'A wonderful video of a magnificent cat.'
 }
 
-begin
-  response = client.index_document(engine_name, document)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.index_document(engine_name, document)
 ```
 
-#### Indexing: Creating or Updating Documents
+#### Indexing: Creating or Replacing Documents
 
 ```ruby
 engine_name = 'favorite-videos'
@@ -69,26 +64,37 @@ documents = [
   }
 ]
 
-begin
-  response = client.index_documents(engine_name, documents)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.index_documents(engine_name, documents)
 ```
 
-#### Listing Documents
+#### Indexing: Updating Documents (Partial Updates)
+
+```ruby
+engine_name = 'favorite-videos'
+documents = [
+  {
+    :id => 'INscMGmhmX4',
+    :title => 'Updated title'
+  }
+]
+
+client.update_documents(engine_name, documents)
+```
+
+#### Retrieving Documents
 
 ```ruby
 engine_name = 'favorite-videos'
 document_ids = ['INscMGmhmX4', 'JNDFojsd02']
 
-begin
-  response = client.get_documents(engine_name, document_ids)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.get_documents(engine_name, document_ids)
+```
+
+#### Listing Documents
+```ruby
+engine_name = 'favorite-videos'
+
+client.list_documents(engine_name)
 ```
 
 #### Destroying Documents
@@ -97,23 +103,13 @@ end
 engine_name = 'favorite-videos'
 document_ids = ['INscMGmhmX4', 'JNDFojsd02']
 
-begin
-  response = client.destroy_documents(engine_name, document_ids)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.destroy_documents(engine_name, document_ids)
 ```
 
 #### Listing Engines
 
 ```ruby
-begin
-  response = client.list_engines
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.list_engines
 ```
 
 #### Retrieving Engines
@@ -121,12 +117,7 @@ end
 ```ruby
 engine_name = 'favorite-videos'
 
-begin
-  response = client.get_engine(engine_name)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.get_engine(engine_name)
 ```
 
 #### Creating Engines
@@ -134,12 +125,7 @@ end
 ```ruby
 engine_name = 'favorite-videos'
 
-begin
-  response = client.create_engine(engine_name)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.create_engine(engine_name)
 ```
 
 #### Destroying Engines
@@ -147,12 +133,7 @@ end
 ```ruby
 engine_name = 'favorite-videos'
 
-begin
-  response = client.destroy_engine(engine_name)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.destroy_engine(engine_name)
 ```
 
 #### Searching
@@ -164,12 +145,23 @@ search_fields = { :title => {} }
 result_fields = { :title => { :raw => {} } }
 options = { :search_fields => search_fields, :result_fields => result_fields }
 
-begin
-  response = client.search(engine_name, query, options)
-  puts response
-rescue SwiftypeAppSearch::ClientException => e
-  puts e
-end
+client.search(engine_name, query, options)
+```
+
+#### Multi-Search
+
+```ruby
+engine_name = 'favorite-videos'
+
+queries = [{
+  :query => 'cat',
+  :options => { :search_fields => { :title => {} }}
+},{
+  :query => 'dog',
+  :options => { :search_fields => { :body => {} }}
+}]
+
+client.multi_search(engine_name, queries)
 ```
 
 ## Running Tests

--- a/lib/swiftype-app-search/client/documents.rb
+++ b/lib/swiftype-app-search/client/documents.rb
@@ -7,7 +7,7 @@ module SwiftypeAppSearch
 
       # Retrieve all Documents from the API for the {App Search API}[https://swiftype.com/documentation/app-search/]
       #
-      # @param [String] engine_name the unique Engine names
+      # @param [String] engine_name the unique Engine name
       # @option options see the {App Search API}[https://swiftype.com/documentation/app-search/] for supported options.
       #
       # @return [Array<Hash>] an Array of Documents

--- a/lib/swiftype-app-search/client/documents.rb
+++ b/lib/swiftype-app-search/client/documents.rb
@@ -56,6 +56,20 @@ module SwiftypeAppSearch
         post("engines/#{engine_name}/documents", documents)
       end
 
+      # Update a batch of documents using the {App Search API}[https://swiftype.com/documentation/app-search/].
+      #
+      # @param [String] engine_name the unique Engine name
+      # @param [Array] documents an Array of Document Hashes including valid ids
+      #
+      # @return [Array<Hash>] an Array of processed Document Status hashes
+      #
+      # @raise [SwiftypeAppSearch::InvalidDocument] when any documents have processing errors returned from the api
+      # @raise [Timeout::Error] when timeout expires waiting for statuses
+      def update_documents(engine_name, documents)
+        documents.map! { |document| normalize_document(document) }
+        patch("engines/#{engine_name}/documents", documents)
+      end
+
       # Destroy a batch of documents given a list of IDs
       #
       # @param [Array<String>] ids an Array of Document IDs

--- a/lib/swiftype-app-search/client/documents.rb
+++ b/lib/swiftype-app-search/client/documents.rb
@@ -5,13 +5,23 @@ module SwiftypeAppSearch
   class Client
     module Documents
 
+      # Retrieve all Documents from the API for the {App Search API}[https://swiftype.com/documentation/app-search/]
+      #
+      # @param [String] engine_name the unique Engine names
+      # @option options see the {App Search API}[https://swiftype.com/documentation/app-search/] for supported options.
+      #
+      # @return [Array<Hash>] an Array of Documents
+      def list_documents(engine_name, options = {})
+        params = Utils.symbolize_keys(options)
+        request(:get, "engines/#{engine_name}/documents/list", params)
+      end
+
       # Retrieve Documents from the API by IDs for the {App Search API}[https://swiftype.com/documentation/app-search/]
       #
       # @param [String] engine_name the unique Engine name
       # @param [Array<String>] ids an Array of Document IDs
       #
-      # @return [Array<Hash>] an Array of Documents
-
+      # @return [Hash] list results
       def get_documents(engine_name, ids)
         get("engines/#{engine_name}/documents", ids)
       end

--- a/lib/swiftype-app-search/client/engines.rb
+++ b/lib/swiftype-app-search/client/engines.rb
@@ -11,8 +11,10 @@ module SwiftypeAppSearch
         get("engines/#{engine_name}")
       end
 
-      def create_engine(engine_name)
-        post("engines", :name => engine_name)
+      def create_engine(engine_name, language = nil)
+        params = { :name => engine_name }
+        params[:language] = language if language
+        post("engines", params)
       end
 
       def destroy_engine(engine_name)

--- a/lib/swiftype-app-search/client/search.rb
+++ b/lib/swiftype-app-search/client/search.rb
@@ -7,10 +7,29 @@ module SwiftypeAppSearch
       # @param [String] query the search query
       # @option options see the {App Search API}[https://swiftype.com/documentation/app-search/] for supported search options.
       #
-      # @return [Array<Hash>] an Array of Document destroy result hashes
+      # @return [Hash] search results
       def search(engine_name, query, options = {})
         params = Utils.symbolize_keys(options).merge(:query => query)
         request(:post, "engines/#{engine_name}/search", params)
+      end
+
+      # Run multiple searches for documents on a single request
+      #
+      # @param [String] engine_name the unique Engine name
+      # @param [{query: String, options: Hash}] searches to execute
+      # see the {App Search API}[https://swiftype.com/documentation/app-search/] for supported search options.
+      #
+      # @return [Array<Hash>] an Array of searh sesults
+      def multi_search(engine_name, searches)
+        params = searches.map do |search|
+          search = Utils.symbolize_keys(search)
+          query = search[:query]
+          options = search[:options] || {}
+          Utils.symbolize_keys(options).merge(:query => query)
+        end
+        request(:post, "engines/#{engine_name}/multi_search", {
+          queries: params
+        })
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -249,6 +249,12 @@ describe SwiftypeAppSearch::Client do
         expect { client.get_engine(engine_name) }.to_not raise_error
       end
 
+      it 'should accept an optional language parameter' do
+        expect { client.get_engine(engine_name) }.to raise_error(SwiftypeAppSearch::NonExistentRecord)
+        client.create_engine(engine_name, 'da')
+        expect(client.get_engine(engine_name)).to match('name' => anything, 'type' => anything, 'language' => 'da')
+      end
+
       it 'should return an engine object' do
         engine = client.create_engine(engine_name)
         expect(engine).to be_kind_of(Hash)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -99,6 +99,31 @@ describe SwiftypeAppSearch::Client do
       end
     end
 
+    describe '#update_documents' do
+      let(:documents) { [document, second_document] }
+      let(:second_document_id) { 'another_id' }
+      let(:second_document) { { 'id' => second_document_id, 'url' => 'https://www.youtube.com/watch?v=9T1vfsHYiKY' } }
+      let(:updates) { [ {
+        'id' => second_document_id,
+        'url' => 'https://www.example.com'
+      } ] }
+
+      subject { client.update_documents(engine_name, updates) }
+
+      before do
+        client.index_documents(engine_name, documents)
+      end
+
+      # Note that since indexing a document takes up to a minute,
+      # we don't expect this to succeed, so we simply verify that
+      # the request responded with the correct 'id', even though
+      # the 'errors' object likely contains errors.
+      it 'should update existing documents' do
+        response = subject
+        expect(subject).to match(['id' => second_document_id, 'errors' => anything])
+      end
+    end
+
     describe '#get_documents' do
       let(:documents) { [first_document, second_document] }
       let(:first_document_id) { 'id' }


### PR DESCRIPTION
Fixes #28

Added the following:
- Second parameter to `create_engine` for `language`
- `update_documents` for partial updates
- `list_documents`
- `multi_search`
