### PR TITLE
Handling multi_search errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1416 @@
+AllCops:
+  DisabledByDefault: true
+
+######################### Layout ###########################
+
+Layout/AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
+  Enabled: false
+
+Layout/AlignArray:
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
+  Enabled: true
+
+Layout/AlignHash:
+  Description: >-
+                 Align the elements of a hash literal if they span more than
+                 one line.
+  Enabled: true
+
+Layout/AlignParameters:
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Description: 'Put end statement of multiline block on its own line.'
+  Enabled: true
+
+Layout/CaseIndentation:
+  Description: 'Indentation of when in a case/when/[else/]end.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
+  EnforcedStyle: end
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Description: 'Checks the indentation of hanging closing parentheses.'
+  Enabled: true
+
+Layout/CommentIndentation:
+  Description: 'Indentation of comments.'
+  Enabled: true
+
+Layout/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  EnforcedStyle: leading
+  Enabled: true
+
+Layout/ElseAlignment:
+  Description: 'Align elses and elsifs correctly.'
+  Enabled: true
+
+Layout/EmptyLineBetweenDefs:
+  Description: 'Use empty lines between defs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
+  Enabled: true
+
+Layout/EmptyLines:
+  Description: 'Do not use several empty lines in a row.'
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Description: 'Keep blank lines around access modifiers.'
+  Enabled: true
+
+Layout/EmptyLinesAroundArguments:
+  Description: 'Checks if empty lines exist around the arguments of a method invocation.'
+  Enabled: true
+
+Layout/EmptyLinesAroundBlockBody:
+  Description: 'Keeps track of empty lines around block bodies.'
+  EnforcedStyle: no_empty_lines
+  Enabled: true
+
+Layout/EmptyLinesAroundClassBody:
+  Description: 'Keeps track of empty lines around class bodies.'
+  Enabled: false
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Description: 'Checks if empty lines exist around the bodies of `begin` sections. Does not check empty lines at `begin` body beginning/end and around method definition body.'
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Description: 'Keeps track of empty lines around method bodies.'
+  Enabled: true
+
+Layout/EmptyLinesAroundModuleBody:
+  Description: 'Keeps track of empty lines around module bodies.'
+  Enabled: false
+
+Layout/EndOfLine:
+  Description: 'Use Unix-style line endings.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
+  Enabled: true
+
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: true
+
+Layout/FirstArrayElementLineBreak:
+  Description: 'Checks for a line break before the first element in a multi-line array. @ahoey: Halle-fucking-lujah.'
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Description: 'Checks for a line break before the first element in a multi-line hash.'
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Description: 'Checks for a line break before the first argument in a multi-line method call.'
+  Enabled: true
+
+Layout/FirstMethodParameterLineBreak:
+  Description: 'Checks for a line break before the first parameter in a mult-line method parameter definition.'
+  Enabled: true
+
+Layout/FirstParameterIndentation:
+  Description: 'Checks the indentation of the first parameter in a method call.'
+  EnforcedStyle: consistent
+  Enabled: true
+
+Layout/IndentArray:
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
+  EnforcedStyle: consistent
+  Enabled: true
+
+Layout/IndentAssignment:
+  Description: 'Checks the indentation of the first line of the right-hand side of a multi-line assignment.'
+  Enabled: true
+
+Layout/IndentHash:
+  Description: 'Checks the indentation of the first key in a hash literal.'
+  EnforcedStyle: consistent
+  Enabled: true
+
+Layout/IndentationConsistency:
+  Description: 'Keep indentation straight.'
+  Enabled: true
+
+Layout/IndentationWidth:
+  Description: 'Use 2 spaces for indentation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Width: 2
+  Enabled: true
+
+Layout/InitialIndentation:
+  Description: 'Checks the indentation of the first non-blank non-comment line in a file.'
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Description: 'Comments should start with a space.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
+  Enabled: true
+
+Layout/MultilineArrayBraceLayout:
+  Description: 'Checks that the closing brace in an array literal is on a new line.'
+  EnforcedStyle: new_line
+  Enabled: true
+
+Layout/MultilineAssignmentLayout:
+  EnforcedStyle: same_line
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: true
+
+Layout/MultilineHashBraceLayout:
+  Description: 'Checks that the closing brace in an hash literal is on a new line.'
+  EnforcedStyle: new_line
+  Enabled: true
+
+Layout/MultilineMethodCallBraceLayout:
+  Description: 'Checks that the closing brace in a multi-line method call is on a new line.'
+  EnforcedStyle: new_line
+  Enabled: true
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Description: 'Checks that the closing brace in a method definition is on a new line.'
+  EnforcedStyle: new_line
+  Enabled: true
+
+Layout/MultilineOperationIndentation:
+  Description: 'Checks indentation of binary operations that span more than one line.'
+  EnforcedStyle: indented
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Description: 'Align rescues and ensures correctly.'
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Description: 'Use spaces after colons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Description: 'Use spaces after commas.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Description: 'Do not put a space between a method name and the opening parenthesis in a method definition.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Description: 'Tracks redundant space after the ! operator.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Description: 'Use spaces after semicolons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: true
+
+Layout/SpaceAroundBlockParameters:
+  Description: 'Checks the spacing inside and after block parameters pipes.'
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
+  EnforcedStyle: space
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Description: 'Use spaces around keywords.'
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Description: 'Use a single space around operators.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Description: 'No spaces before commas.'
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Description: >-
+                 Checks for missing space between code and a comment on the
+                 same line.
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Description: 'No spaces before semicolons.'
+  Enabled: true
+
+Layout/SpaceInLambdaLiteral:
+  Description: 'Require no space between stabby and arguments.'
+  EnforcedStyle: require_no_space
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Description: 'Do not space pad array literals.'
+  EnforcedStyle: no_space
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Description: 'Checks for unnecessary spaces in percent literal arrays.'
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Description: 'Checks that blocks braces are space padded.'
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Description: 'Use spaces inside hash literal braces - or do not.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Description: 'No spaces after ( or before ).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Description: 'Checks for unnecessary spaces inside %i%w%x literals.'
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Description: 'No spaces inside range literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  Description: 'No spaces in collection reference array brackets.'
+  Enabled: true
+
+Layout/SpaceInsideStringInterpolation:
+  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
+  Enabled: true
+
+Layout/Tab:
+  Description: 'No hard tabs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Enabled: true
+
+Layout/TrailingBlankLines:
+  Description: 'Checks trailing blank lines and final newline.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Description: 'Avoid trailing whitespace.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
+  Enabled: true
+
+######################### Lint #############################
+
+Lint/AmbiguousBlockAssociation:
+  Description: 'Checks for ambiguous block association with method without params.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#syntax'
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Description: >-
+                 Checks for ambiguous operators in the first argument of a
+                 method invocation without parentheses.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parenthesis.
+  Enabled: true
+
+Lint/AssignmentInCondition:
+  Description: 'Do not use assignment in conditions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
+  Enabled: false
+
+Lint/BlockAlignment:
+  Description: 'Checks whether the end keywords are aligned properly for do end blocks.'
+  Enabled: true
+
+Lint/BooleanSymbol:
+  Description: 'Do not create :true or :false symbols'
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Description: 'Do not refer to the keyword argument in the default value.'
+  Enabled: true
+
+Lint/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
+  Enabled: true
+
+Lint/Debugger:
+  Description: 'Check for debugger calls.'
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Description: 'Check for deprecated class method calls.'
+  Enabled: true
+
+Lint/DuplicateCaseCondition:
+  Description: 'Check for there are no duplicate case conditions.'
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Description: 'Check for duplicate methods calls.'
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Description: 'Check for duplicate hash keys.'
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Description: 'Check for immutable argument given to each_with_object.'
+  Enabled: true
+
+Lint/ElseLayout:
+  Description: 'Check for odd code arrangement in an else block.'
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Description: 'Checks for empty ensure block.'
+  Enabled: true
+
+Lint/EmptyExpression:
+  Description: 'Checks for empty if/unless/while expressions.'
+  Enabled: true
+
+Lint/EndAlignment:
+  Description: 'Checks whether the end keywords are aligned properly.'
+  EnforcedStyleAlignWith: 'variable'
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Description: 'Checks for empty string interpolation.'
+  Enabled: true
+
+Lint/EndInMethod:
+  Description: 'END blocks should not be placed inside method definitions.'
+  Enabled: true
+
+Lint/EnsureReturn:
+  Description: 'Do not use return in an ensure block.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Description: 'The number of parameters to format/sprint must match the fields.'
+  Enabled: true
+
+Lint/HandleExceptions:
+  Description: 'Do not suppress exception.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Description: 'Checks for implicit string concatentation of string literals on the same line.'
+  Enabled: true
+
+Lint/IneffectiveAccessModifier:
+  Description: 'Checks for `private` or `protected` on class methods.'
+  Enabled: true
+
+Lint/InheritException:
+  Description: 'Do not inherit from Exception. Use RuntimeError or StandardError instead.'
+  EnforcedStyle: standard_error
+  Enabled: true
+
+Lint/LiteralAsCondition:
+  Description: 'Checks of literals used in conditions.'
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Description: 'Checks for literals used in interpolation.'
+  Enabled: true
+
+Lint/Loop:
+  Description: >-
+                 Use Kernel#loop with break rather than begin/end/until or
+                 begin/end/while for post-loop tests.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
+  Enabled: true
+
+Lint/NestedMethodDefinition:
+  Description: 'Do not use nested method definitions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
+  Enabled: true
+
+Lint/NestedPercentLiteral:
+  Description: 'Do not use nested percent literals.'
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Description: 'Do not emit the accumulator when calling `next` in a `reduce` block'
+  Enabled: true
+
+Lint/NonLocalExitFromIterator:
+  Description: 'Do not use return in iterator to cause non-local exit.'
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Description: >-
+                 Checks for method calls with a space before the opening
+                 parenthesis.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: true
+
+Lint/RequireParentheses:
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
+  Enabled: true
+
+Lint/RescueException:
+  Description: 'Avoid rescuing the Exception class.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Description: >-
+                 Do not use the same name as outer local variable
+                 for block arguments or block local variables.
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Description: 'Do not use prefix `_` for a variable that is used.'
+  Enabled: true
+
+Lint/UnneededDisable:
+  Description: >-
+                 Checks for rubocop:disable comments that can be removed.
+                 Note: this cop is not disabled when disabling all cops.
+                 It must be explicitly disabled.
+  Enabled: true
+
+Lint/UnneededSplatExpansion:
+  Description: 'Checks for unneeded usages of splat expansion.'
+  Enabled: true
+
+Lint/UnreachableCode:
+  Description: 'Unreachable code.'
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Description: 'Checks for unused block arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: true
+
+Lint/UnusedMethodArgument:
+  Description: 'Checks for unused method arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  Description: 'Checks for useless access modifiers.'
+  Enabled: true
+
+Lint/UselessAssignment:
+  Description: 'Checks for useless assignment to a local variable.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: true
+
+Lint/UselessComparison:
+  Description: 'Checks for comparison of something with itself.'
+  Enabled: true
+
+Lint/UselessElseWithoutRescue:
+  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Description: 'Checks for useless setter call to a local variable.'
+  Enabled: true
+
+Lint/Void:
+  Description: 'Possible use of operator/literal/variable in void context.'
+  Enabled: true
+
+######################### Metrics ##########################
+
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Enabled: false
+  Max: 20
+
+Metrics/BlockNesting:
+  Description: 'Avoid excessive block nesting.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
+  Enabled: true
+  Max: 4
+
+Metrics/ClassLength:
+  Description: 'Avoid classes longer than 1000 lines of code.'
+  Enabled: true
+  Max: 1000
+
+Metrics/CyclomaticComplexity:
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
+  Enabled: true
+  Max: 20
+
+Metrics/LineLength:
+  Description: 'Limit lines to 80 characters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Enabled: false
+
+Metrics/MethodLength:
+  Description: 'Avoid methods longer than 30 lines of code.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
+  Enabled: true
+  Exclude:
+    - app/views/**/*.html.rb
+  Max: 100
+
+Metrics/ModuleLength:
+  Description: 'Avoid modules longer than 250 lines of code.'
+  Enabled: true
+  Max: 250
+
+Metrics/ParameterLists:
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
+  Enabled: true
+  Max: 6
+
+Metrics/PerceivedComplexity:
+  Description: >-
+                 A complexity metric geared towards measuring complexity for a
+                 human reader.
+  Enabled: false
+
+######################### Naming ###########################
+
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+
+Naming/AsciiIdentifiers:
+  Description: 'Use only ascii symbols in identifiers.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Description: 'When defining binary operators, name the argument other.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
+  Enabled: false
+
+Naming/ClassAndModuleCamelCase:
+  Description: 'Use CamelCase for classes and modules.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#camelcase-classes'
+  Enabled: true
+
+Naming/ConstantName:
+  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
+  Enabled: true
+
+Naming/FileName:
+  Description: 'Use snake_case for source file names.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
+  Enabled: true
+
+Naming/MethodName:
+  Description: 'Use the configured style when naming methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
+  EnforcedStyle: snake_case
+  Enabled: true
+
+Naming/PredicateName:
+  Description: 'Check the names of predicate methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
+  Enabled: false
+
+Naming/VariableName:
+  Description: 'Use the configured style when naming variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
+  EnforcedStyle: snake_case
+  Enabled: true
+
+######################### Performance #######################
+
+Performance/CompareWithBlock:
+  Description: 'Identifies places where `sort { |a, b| a.foo <=> b.foo }` can be replaced by `sort_by(&:foo)`.'
+  Enabled: true
+
+Performance/Count:
+  Description: >-
+                  Use `count` instead of `select...size`, `reject...size`,
+                  `select...count`, `reject...count`, `select...length`,
+                  and `reject...length`.
+  Enabled: true
+
+Performance/Detect:
+  Description: >-
+                  Use `detect` instead of `select.first`, `find_all.first`,
+                  `select.last`, and `find_all.last`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
+  Enabled: true
+
+Performance/EndWith:
+  Description: 'Identifies unnecessary use of a regex where `String.end_with?` would suffice.'
+  Enabled: true
+
+Performance/FlatMap:
+  Description: >-
+                  Use `Enumerable#flat_map`
+                  instead of `Enumerable#map...Array#flatten(1)`
+                  or `Enumberable#collect..Array#flatten(1)`
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
+  Enabled: true
+  EnabledForFlattenWithoutParams: false
+  # If enabled, this cop will warn about usages of
+  # `flatten` being called without any parameters.
+  # This can be dangerous since `flat_map` will only flatten 1 level, and
+  # `flatten` without any parameters can flatten multiple levels.
+
+Performance/RedundantBlockCall:
+  Description: 'Identifies the use of a `&block` parameter and `block.call`, where `yield` would be sufficient.'
+  Enabled: true
+
+Performance/RedundantMatch:
+  Description: 'Do not use `Regexp#match` or `String#match` where =~ is sufficient.'
+  Enabled: true
+
+Performance/RedundantMerge:
+  Description: 'Use Hash#[]= instead of Hash#merge!'
+  Enabled: true
+
+Performance/RedundantSortBy:
+  Description: 'Use `sort` instead of `sort_by` where possible.'
+  Enabled: true
+
+Performance/ReverseEach:
+  Description: 'Use `reverse_each` instead of `reverse.each`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
+  Enabled: true
+
+Performance/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: true
+
+Performance/Size:
+  Description: >-
+                  Use `size` instead of `count` for counting
+                  the number of elements in `Array` and `Hash`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
+  Enabled: true
+
+Performance/StartWith:
+  Description: 'Use `String#start_with?` instead of regex where possible'
+  Enabled: true
+
+Performance/StringReplacement:
+  Description: >-
+                  Use `tr` instead of `gsub` when you are replacing the same
+                  number of characters. Use `delete` instead of `gsub` when
+                  you are deleting characters.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
+  Enabled: true
+
+######################### Rails ###########################
+
+Rails/ActionFilter:
+  Description: 'Enforces consistent use of action filter methods.'
+  Enabled: false
+
+Rails/Blank:
+  Description: 'Checks for code that can be changed to `blank?`'
+  Enabled: true
+
+Rails/Date:
+  Description: >-
+                  Checks the correct usage of date aware methods,
+                  such as Date.today, Date.current etc.
+  Enabled: false
+
+Rails/Delegate:
+  Description: 'Prefer delegate method for delegations.'
+  Enabled: false
+
+Rails/FindBy:
+  Description: 'Prefer find_by over where.first.'
+  Enabled: false
+
+Rails/FindEach:
+  Description: 'Prefer all.find_each over all.find.'
+  Enabled: false
+
+Rails/HasAndBelongsToMany:
+  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  Enabled: false
+
+Rails/Output:
+  Description: 'Checks for calls to puts, print, etc.'
+  Enabled: false
+
+Rails/ReadWriteAttribute:
+  Description: >-
+                 Checks for read_attribute(:attr) and
+                 write_attribute(:attr, val).
+  Enabled: false
+
+Rails/SafeNavigation:
+  Description: 'Prefer safe navigation operator to try!'
+  Enabled: true
+
+Rails/ScopeArgs:
+  Description: 'Checks the arguments of ActiveRecord scopes.'
+  Enabled: false
+
+Rails/TimeZone:
+  Description: 'Checks the correct usage of time zone aware methods.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
+  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: false
+
+Rails/Validation:
+  Description: 'Use validates :attribute, hash of validations.'
+  Enabled: false
+
+######################### Security #########################
+
+Security/Eval:
+  Description: 'The use of eval represents a serious security risk.'
+  Enabled: true
+
+######################### Style ############################
+
+Style/Alias:
+  Description: 'Use alias_method instead of alias. The lexical scope of alias can lead to unpredicatbility.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
+  EnforcedStyle: prefer_alias_method
+  Enabled: true
+
+Style/AndOr:
+  Description: 'Use &&/|| instead of and/or.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-and-or-or'
+  Enabled: true
+
+Style/ArrayJoin:
+  Description: 'Use Array#join instead of Array#*.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#array-join'
+  Enabled: true
+
+Style/AsciiComments:
+  Description: 'Use only ascii symbols in comments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
+  Enabled: false
+
+Style/Attr:
+  Description: 'Checks for uses of Module#attr.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
+  Enabled: true
+
+Style/BarePercentLiterals:
+  Description: 'Checks if usage of %() or %Q() matches configuration.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand'
+  Enabled: false
+
+Style/BeginBlock:
+  Description: 'Avoid the use of BEGIN blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks'
+  Enabled: true
+
+Style/BlockComments:
+  Description: 'Do not use block comments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
+  Enabled: true
+
+Style/BlockDelimiters:
+  Description: >-
+                Avoid using {...} for multi-line blocks (multiline chaining is
+                always ugly).
+                Prefer {...} over do...end for single-line blocks.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: true
+
+Style/BracesAroundHashParameters:
+  Description: 'Checks for braces around the last argument of method call if the last parameter is a hash.'
+  Enabled: true
+
+Style/CaseEquality:
+  Description: 'Avoid explicit use of the case equality operator(===).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
+  Enabled: true
+
+Style/CharacterLiteral:
+  Description: 'Checks for uses of character literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
+  Enabled: true
+
+Style/ClassAndModuleChildren:
+  Description: 'Checks style of children classes and modules.'
+  Enabled: false
+
+Style/ClassCheck:
+  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
+  Enabled: false
+
+Style/ClassMethods:
+  Description: 'Use self when defining module/class methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#def-self-class-methods'
+  Enabled: false
+
+Style/ClassVars:
+  Description: 'Avoid the use of class variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
+  Enabled: true
+
+Style/ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
+  Enabled: true
+
+Style/ColonMethodDefinition:
+  Description: 'Do not use :: for method definition.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
+  Enabled: true
+
+Style/CommandLiteral:
+  Description: 'Use `` or %x around command literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-x'
+  Enabled: false
+
+Style/CommentAnnotation:
+  Description: 'Checks formatting of annotation comments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Description: 'Checks for `if` and `case` statements where each branch assigns the same variable.'
+  Enabled: true
+
+Style/DateTime:
+  Description: 'Checks for use of DateTime that should be replaced by `Date` or `Time`'
+  Enabled: true
+
+Style/DefWithParentheses:
+  Description: 'Use def with parentheses when there are arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
+  Enabled: true
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+Style/DoubleNegation:
+  Description: 'Checks for uses of double negation (!!).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
+  Enabled: false
+
+Style/EachWithObject:
+  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Enabled: true
+
+Style/EmptyBlockParameter:
+  Description: 'Empty pipes in blocks are redundant.'
+  Enabled: true
+
+Style/EmptyElse:
+  Description: 'Avoid empty else-clauses.'
+  EnforcedStyle: empty
+  Enabled: true
+
+Style/EmptyLambdaParameter:
+  Description: 'Skip parentheses for empty lambda parameters.'
+  Enabled: true
+
+Style/EmptyLiteral:
+  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'
+  Enabled: true
+
+Style/EndBlock:
+  Description: 'Avoid the use of END blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
+  Enabled: true
+
+Style/EvenOdd:
+  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
+  Enabled: true
+
+Style/FlipFlop:
+  Description: 'Checks for flip flops.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
+  Enabled: false
+
+Style/For:
+  Description: 'Checks use of for or each in multiline loops.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-for-loops'
+  Enabled: true
+
+Style/FormatString:
+  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Description: 'This enforces that the `# frozen_string_literal: true` comment is at the top of every file to enable frozen string literals.'
+  Enabled: true
+
+Style/GlobalVars:
+  Description: 'Do not introduce global variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'
+  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
+  Enabled: false
+
+Style/GuardClause:
+  Description: 'Check for conditionals that can be replaced with guard clauses.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
+Style/HashSyntax:
+  Description: 'Prefer hash rockets.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
+  EnforcedStyle: hash_rockets
+  Enabled: true
+
+Style/IfUnlessModifier:
+  Description: >-
+                 Favor modifier if/unless usage when you have a
+                 single-line body.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier'
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Description: 'Do not use if and unless as modifiers of other if or unless statements.'
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Description: 'Do not use if x; .... Use the ternary operator instead.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
+  Enabled: true
+
+Style/InfiniteLoop:
+  Description: 'Use Kernel#loop for infinite loops.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
+  Enabled: true
+
+Style/InverseMethods:
+  Description: 'Do not use `not` or `!` when an inverse method can be used.'
+  Enabled: true
+
+Style/Lambda:
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
+  Enabled: false
+
+Style/LambdaCall:
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
+  Enabled: false
+
+Style/MethodCallWithArgsParentheses:
+  Description: 'Use parentheses for method calls with arguments.'
+  IgnoredMethods:
+    - puts
+    - raise
+    - require
+    - load
+    - render
+    - respond_to
+    - widget
+    - extend
+    - include
+  Exclude:
+    - Gemfile
+    - db/migrate
+    - app/views/**/*.html.rb
+    - spec/**/*.rb
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Description: 'Do not use parentheses for method calls with no arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Description: >-
+                 Checks if the method definitions have or don't have
+                 parentheses.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
+  Enabled: true
+
+Style/MixinGrouping:
+  Description: 'Separate include statements.'
+  Enabled: true
+
+Style/ModuleFunction:
+  Description: 'Checks for usage of `extend self` in modules.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: false
+
+Style/MultilineIfThen:
+  Description: 'Do not use then for multi-line if/unless.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Description: >-
+                 Avoid multi-line ?: (the ternary operator);
+                 use if/unless instead.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary'
+  Enabled: true
+
+Style/NegatedIf:
+  Description: >-
+                 Favor unless over if for negative conditions
+                 (or control flow or).
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
+  Enabled: true
+
+Style/NegatedWhile:
+  Description: 'Favor until over while for negative conditions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#until-for-negatives'
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Description: 'Use one expression per branch in a ternary operator.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-ternary'
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Description: 'Use parentheses for nested method calls with arguments.'
+  Enabled: true
+
+Style/Next:
+  Description: 'Use `next` to skip iteration instead of a condition at the end.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
+Style/NilComparison:
+  Description: 'Prefer x.nil? to x == nil.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
+  Enabled: true
+
+Style/NonNilCheck:
+  Description: 'Checks for redundant nil checks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks'
+  Enabled: true
+
+Style/Not:
+  Description: 'Use ! instead of not.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
+  Enabled: true
+
+Style/NumericLiterals:
+  Description: >-
+                 Add underscores to large numeric literals to improve their
+                 readability.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: false
+
+Style/OneLineConditional:
+  Description: >-
+                 Favor the ternary operator(?:) over
+                 if/then/else/end constructs.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
+  Enabled: true
+
+Style/OptionalArguments:
+  Description: >-
+                 Checks for optional arguments that do not appear at the end
+                 of the argument list
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#optional-arguments'
+  Enabled: true
+
+Style/OrAssignment:
+  Description: 'Use ||= where possible.'
+  Enabled: true
+
+Style/ParallelAssignment:
+  Description: >-
+                  Check for simple usages of parallel assignment.
+                  It will only warn when the number of variables
+                  matches on both sides of the assignment.
+                  This also provides performance benefits
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Description: >-
+                 Don't use parentheses around the condition of an
+                 if/unless/while.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-parens-if'
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Description: 'Use `%`-literal delimiters consistently.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
+  Enabled: false
+
+Style/PercentQLiterals:
+  Description: 'Checks if uses of %Q/%q match the configured preference.'
+  Enabled: true
+
+Style/PerlBackrefs:
+  Description: 'Avoid Perl-style regex back references.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Description: 'Checks for use of deprecated Hash methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
+  Enabled: false
+
+Style/Proc:
+  Description: 'Use proc instead of Proc.new.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc'
+  Enabled: false
+
+Style/RaiseArgs:
+  Description: 'Checks the arguments passed to raise/fail.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
+  Enabled: false
+
+Style/RandomWithOffset:
+  Description: 'Do not add numbers to random numbers. Use ranges instead.'
+  Enabled: true
+
+Style/RedundantBegin:
+  Description: 'Do not use begin blocks when they are not needed.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#begin-implicit'
+  Enabled: true
+
+Style/RedundantConditional:
+  Description: 'Checks for conditional returning of true/false in conditionals'
+  Enabled: true
+
+Style/RedundantException:
+  Description: 'Checks for an obsolete RuntimeException argument in raise/fail.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror'
+  Enabled: false
+
+Style/RedundantReturn:
+  Description: 'Do not use return where it is not required.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-return'
+  Enabled: false
+
+Style/RedundantSelf:
+  Description: 'Do not use self where it is not needed.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-self-unless-required'
+  Enabled: true
+
+Style/RegexpLiteral:
+  Description: 'Use / or %r around regular expressions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
+  Enabled: false
+
+Style/RescueModifier:
+  Description: 'Avoid using rescue in its modifier form.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
+  Enabled: false
+
+Style/SafeNavigation:
+  Description: 'Checks for places where the safe navigation operator should have been used.'
+  Enabled: true
+
+Style/SelfAssignment:
+  Description: >-
+                 Checks for places where self-assignment shorthand should have
+                 been used.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
+  Enabled: true
+
+Style/Semicolon:
+  Description: 'Do not use semicolons to terminate expressions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon'
+  Enabled: true
+
+Style/SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
+  EnforcedStyle: only_raise
+  Enabled: true
+
+Style/SingleLineBlockParams:
+  Description: 'Enforces the names of some block params.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#reduce-blocks'
+  Enabled: false
+
+Style/SingleLineMethods:
+  Description: 'Avoid single-line methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Description: 'Avoid Perl-style global variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
+  Enabled: true
+
+Style/StabbyLambdaParentheses:
+  Description: 'Checks for parentheses around stabby lambda arugments.'
+  EnforcedStyle: require_parentheses
+  Enabled: true
+
+Style/StringLiterals:
+  Description: 'Checks if uses of quotes match the configured preference.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
+  EnforcedStyle: single_quotes
+  Enabled: true
+
+Style/StringLiteralsInInterpolation:
+  Description: >-
+                 Checks if uses of quotes inside expressions in interpolated
+                 strings match the configured preference.
+  EnforcedStyle: single_quotes
+  Enabled: true
+
+Style/StructInheritance:
+  Description: 'Checks for inheritance from Struct.new.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new'
+  Enabled: false
+
+Style/SymbolLiteral:
+  Description: 'Use plain symbols instead of string symbols when possible.'
+  Enabled: true
+
+Style/SymbolProc:
+  Description: 'Use symbols as procs instead of blocks when possible.'
+  Enabled: true
+
+Style/TernaryParentheses:
+  Description: 'Use parentheses in ternary conditions only when using complex conditions.'
+  EnforcedStyle: require_parentheses_when_complex
+  Enabled: true
+
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in parameter lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
+  EnforcedStyleForMultiline: no_comma
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: consistent_comma
+  Enabled: false
+
+Style/TrailingMethodEndStatement:
+  Description: 'Checks for trailing end after the method definition body.'
+  Enabled: true
+
+Style/TrailingUnderscoreVariable:
+  Description: >-
+                 Checks for the usage of unneeded trailing underscores at the
+                 end of parallel variable assignment.
+  Enabled: true
+
+Style/TrivialAccessors:
+  Description: 'Prefer attr_* methods to trivial readers/writers.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
+  Enabled: true
+
+Style/UnlessElse:
+  Description: >-
+                 Do not use unless with else. Rewrite these with the positive
+                 case first.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
+  Enabled: true
+
+Style/UnneededCapitalW:
+  Description: 'Checks for %W when interpolation is not needed.'
+  Enabled: false
+
+Style/UnneededInterpolation:
+  Description: 'Checks for unnecessary interpolation.'
+  Enabled: true
+
+Style/UnneededPercentQ:
+  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
+  Enabled: false
+
+Style/VariableInterpolation:
+  Description: >-
+                 Don't interpolate global, instance and class variables
+                 directly in strings.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#curlies-interpolate'
+  Enabled: false
+
+Style/WhenThen:
+  Description: 'Use when x then ... for one-line cases.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#one-line-cases'
+  Enabled: false
+
+Style/WhileUntilDo:
+  Description: 'Checks for redundant do after while or until.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do'
+  Enabled: true
+
+Style/WhileUntilModifier:
+  Description: >-
+                 Favor modifier while/until usage when you have a
+                 single-line body.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier'
+  Enabled: true
+
+Style/WordArray:
+  Description: 'Use %w or %W for arrays of words.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
+  MinSize: 3
+  Enabled: true
+
+Style/ZeroLengthPredicate:
+  Description: 'Checks for numeric comparisons that can be replaced by predicate method, such as `empty?`.'
+  Enabled: true

--- a/lib/swiftype-app-search/exceptions.rb
+++ b/lib/swiftype-app-search/exceptions.rb
@@ -3,7 +3,11 @@ module SwiftypeAppSearch
     attr_reader :errors
 
     def initialize(response)
-      @errors = response['errors'] || [ response ]
+      if response.kind_of?(Array)
+        @errors = response.map{ |r| r['errors'] }.flatten
+      else
+        @errors = response['errors'] || [ response ]
+      end
       message = (errors.count == 1) ? "Error: #{errors.first}" : "Errors: #{errors.inspect}"
       super(message)
     end

--- a/lib/swiftype-app-search/exceptions.rb
+++ b/lib/swiftype-app-search/exceptions.rb
@@ -3,10 +3,10 @@ module SwiftypeAppSearch
     attr_reader :errors
 
     def initialize(response)
-      if response.kind_of?(Array)
-        @errors = response.map{ |r| r['errors'] }.flatten
+      @errors = if response.is_a?(Array)
+        response.flat_map { |r| r['errors'] }
       else
-        @errors = response['errors'] || [ response ]
+        response['errors'] || [response]
       end
       message = (errors.count == 1) ? "Error: #{errors.first}" : "Errors: #{errors.inspect}"
       super(message)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,7 +3,7 @@ require 'config_helper'
 describe SwiftypeAppSearch::Client do
   let(:engine_name) { "ruby-client-test-#{Time.now.to_i}" }
 
-  include_context "App Search Credentials"
+  include_context 'App Search Credentials'
   let(:client) { SwiftypeAppSearch::Client.new(client_options) }
 
   before(:all) do
@@ -17,15 +17,15 @@ describe SwiftypeAppSearch::Client do
     @static_client = SwiftypeAppSearch::Client.new(client_options)
     @static_client.create_engine(@static_engine_name)
 
-    @document1 = { 'id' => '1', 'title': 'The Great Gatsby' }
-    @document2 = { 'id' => '2', 'title': 'Catcher in the Rye' }
+    @document1 = { 'id' => '1', 'title' => 'The Great Gatsby' }
+    @document2 = { 'id' => '2', 'title' => 'Catcher in the Rye' }
     @documents = [@document1, @document2]
     @static_client.index_documents(@static_engine_name, @documents)
 
     # Wait until documents are indexed
     start = Time.now
     ready = false
-    while (!ready)
+    until (ready)
       sleep(3)
       results = @static_client.search(@static_engine_name, '')
       ready = true if results['results'].length == 2
@@ -41,9 +41,9 @@ describe SwiftypeAppSearch::Client do
     it 'should include client name and version in headers' do
       stub_request(:any, "#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines")
       client.list_engines
-      expect(WebMock).to have_requested(:get, "https://#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines").
-        with(
-          headers: {
+      expect(WebMock).to have_requested(:get, "https://#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines")
+        .with(
+          :headers => {
             'X-Swiftype-Client' => 'swiftype-app-search-ruby',
             'X-Swiftype-Client-Version' => SwiftypeAppSearch::VERSION
           }
@@ -113,20 +113,24 @@ describe SwiftypeAppSearch::Client do
       subject { client.index_documents(engine_name, documents) }
 
       it 'should return an array of document status hashes' do
-        expect(subject).to match([
-          { 'id' => anything, 'errors' => [] },
-          { 'id' => second_document_id, 'errors' => [] }
-        ])
+        expect(subject).to match(
+          [
+            { 'id' => anything, 'errors' => [] },
+            { 'id' => second_document_id, 'errors' => [] }
+          ]
+        )
       end
 
       context 'when one of the documents has processing errors' do
         let(:second_document) { { 'id' => 'too long' * 100 } }
 
         it 'should return respective errors in an array of document processing hashes' do
-          expect(subject).to match([
-            { 'id' => anything, 'errors' => [] },
-            { 'id' => anything, 'errors' => ['Invalid field type: id must be less than 800 characters'] },
-          ])
+          expect(subject).to match(
+            [
+              { 'id' => anything, 'errors' => [] },
+              { 'id' => anything, 'errors' => ['Invalid field type: id must be less than 800 characters'] },
+            ]
+          )
         end
       end
     end
@@ -135,10 +139,14 @@ describe SwiftypeAppSearch::Client do
       let(:documents) { [document, second_document] }
       let(:second_document_id) { 'another_id' }
       let(:second_document) { { 'id' => second_document_id, 'url' => 'https://www.youtube.com/watch?v=9T1vfsHYiKY' } }
-      let(:updates) { [ {
-        'id' => second_document_id,
-        'url' => 'https://www.example.com'
-      } ] }
+      let(:updates) do
+        [
+          {
+            'id' => second_document_id,
+            'url' => 'https://www.example.com'
+          }
+        ]
+      end
 
       subject { client.update_documents(engine_name, updates) }
 
@@ -151,7 +159,6 @@ describe SwiftypeAppSearch::Client do
       # the request responded with the correct 'id', even though
       # the 'errors' object likely contains errors.
       it 'should update existing documents' do
-        response = subject
         expect(subject).to match(['id' => second_document_id, 'errors' => anything])
       end
     end
@@ -199,7 +206,7 @@ describe SwiftypeAppSearch::Client do
 
       context 'when options are specified' do
         it 'will return all documents' do
-          response = client.list_documents(engine_name, {page: { size: 1, current: 2}})
+          response = client.list_documents(engine_name, :page => { :size => 1, :current => 2 })
           expect(response['results'].size).to eq(1)
           expect(response['results'][0]['id']).to eq(second_document_id)
         end
@@ -210,15 +217,14 @@ describe SwiftypeAppSearch::Client do
   context 'Search' do
     describe '#search' do
       subject { @static_client.search(@static_engine_name, query, options) }
-      let (:query) { '' }
-      let (:options) { { 'page' => { 'size' => 2 } } }
+      let(:query) { '' }
+      let(:options) { { 'page' => { 'size' => 2 } } }
 
       it 'should execute a search query' do
-        response = subject
-        expect(response).to match({
+        expect(subject).to match(
           'meta' => anything,
-          'results' => [ anything, anything ]
-        })
+          'results' => [anything, anything]
+        )
       end
     end
 
@@ -226,55 +232,67 @@ describe SwiftypeAppSearch::Client do
       subject { @static_client.multi_search(@static_engine_name, queries) }
 
       context 'when options are provided' do
-        let (:queries) { [
-          { 'query' => 'gatsby', 'options' => { 'page' => { 'size' => 1 } } },
-          { 'query' => 'catcher', 'options' => { 'page' => { 'size' => 1 } } }
-        ] }
+        let(:queries) do
+          [
+            { 'query' => 'gatsby', 'options' => { 'page' => { 'size' => 1 } } },
+            { 'query' => 'catcher', 'options' => { 'page' => { 'size' => 1 } } }
+          ]
+        end
 
         it 'should execute a multi search query' do
           response = subject
-          expect(response).to match([
-            {
-              'meta' => anything,
-              'results' => [ { 'id' => { 'raw' => '1' }, 'title' => anything, '_meta' => anything } ]
-            },
-            {
-              'meta' => anything,
-              'results' => [ { 'id' => { 'raw' => '2' }, 'title' => anything, '_meta' => anything } ]
-            }
-          ])
+          expect(response).to match(
+            [
+              {
+                'meta' => anything,
+                'results' => [{ 'id' => { 'raw' => '1' }, 'title' => anything, '_meta' => anything }]
+              },
+              {
+                'meta' => anything,
+                'results' => [{ 'id' => { 'raw' => '2' }, 'title' => anything, '_meta' => anything }]
+              }
+            ]
+          )
         end
       end
 
       context 'when options are omitted' do
-        let (:queries) { [
-          { 'query' => 'gatsby' },
-          { 'query' => 'catcher' }
-        ] }
+        let(:queries) do
+          [
+            { 'query' => 'gatsby' },
+            { 'query' => 'catcher' }
+          ]
+        end
 
         it 'should execute a multi search query' do
           response = subject
-          expect(response).to match([
-            {
-              'meta' => anything,
-              'results' => [ { 'id' => { 'raw' => '1' }, 'title' => anything, '_meta' => anything } ]
-            },
-            {
-              'meta' => anything,
-              'results' => [ { 'id' => { 'raw' => '2' }, 'title' => anything, '_meta' => anything } ]
-            }
-          ])
+          expect(response).to match(
+            [
+              {
+                'meta' => anything,
+                'results' => [{ 'id' => { 'raw' => '1' }, 'title' => anything, '_meta' => anything }]
+              },
+              {
+                'meta' => anything,
+                'results' => [{ 'id' => { 'raw' => '2' }, 'title' => anything, '_meta' => anything }]
+              }
+            ]
+          )
         end
       end
 
       context 'when a search is bad' do
-        let (:queries) {  [{
-          'query' => 'cat',
-          'options' => { 'search_fields' => { 'taco' => {} }}
-        },{
-          'query' => 'dog',
-          'options' => { 'search_fields' => { 'body' => {} }}
-        }] }
+        let(:queries) do
+          [
+            {
+              'query' => 'cat',
+              'options' => { 'search_fields' => { 'taco' => {} } }
+            }, {
+              'query' => 'dog',
+              'options' => { 'search_fields' => { 'body' => {} } }
+            }
+          ]
+        end
 
         it 'should throw an appropriate error' do
           expect { subject }.to raise_error do |e|

--- a/spec/config_helper.rb
+++ b/spec/config_helper.rb
@@ -1,0 +1,22 @@
+module ConfigHelper
+  def ConfigHelper.get_as_api_key
+    ENV.fetch('AS_API_KEY', 'API_KEY')
+  end
+
+  def ConfigHelper.get_as_host_identifier
+    ENV['AS_ACCOUNT_HOST_KEY'] || ENV['AS_HOST_IDENTIFIER'] || 'ACCOUNT_HOST_KEY'
+  end
+
+  def ConfigHelper.get_as_api_endpoint
+    ENV.fetch('AS_API_ENDPOINT', nil)
+  end
+
+  def ConfigHelper.get_client_options(as_api_key, as_host_identifier, as_api_endpoint)
+    {
+      :api_key => as_api_key,
+      :host_identifier => as_host_identifier
+    }.tap do |opts|
+      opts[:api_endpoint] = as_api_endpoint unless as_api_endpoint.nil?
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,21 +3,17 @@ require 'rspec'
 require 'webmock/rspec'
 require 'awesome_print'
 require 'swiftype-app-search'
+require 'config_helper'
 
 WebMock.allow_net_connect!
 
 RSpec.shared_context "App Search Credentials" do
-  let(:as_api_key) { ENV.fetch('AS_API_KEY', 'API_KEY') }
+  let(:as_api_key) { ConfigHelper.get_as_api_key }
   # AS_ACCOUNT_HOST_KEY is deprecated
-  let(:as_host_identifier) { ENV['AS_ACCOUNT_HOST_KEY'] || ENV['AS_HOST_IDENTIFIER'] || 'ACCOUNT_HOST_KEY' }
-  let(:as_api_endpoint) { ENV.fetch('AS_API_ENDPOINT', nil) }
+  let(:as_host_identifier) { ConfigHelper.get_as_host_identifier }
+  let(:as_api_endpoint) { ConfigHelper.get_as_api_endpoint }
   let(:client_options) do
-    {
-      :api_key => as_api_key,
-      :host_identifier => as_host_identifier
-    }.tap do |opts|
-      opts[:api_endpoint] = as_api_endpoint unless as_api_endpoint.nil?
-    end
+    ConfigHelper.get_client_options(as_api_key, as_host_identifier, as_api_endpoint)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'config_helper'
 
 WebMock.allow_net_connect!
 
-RSpec.shared_context "App Search Credentials" do
+RSpec.shared_context 'App Search Credentials' do
   let(:as_api_key) { ConfigHelper.get_as_api_key }
   # AS_ACCOUNT_HOST_KEY is deprecated
   let(:as_host_identifier) { ConfigHelper.get_as_host_identifier }
@@ -22,5 +22,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = "random"
+  config.order = 'random'
 end


### PR DESCRIPTION
Fixes #31 

Multi-search doesn't *always* return errors in the standard
format, it returns an array of responses, rather than a single
response. For this reason, we need to collect and flatten all
of the error arrays into one.

In addition to adding this spec, I had to add the concept of a
"static" engine for operations that require an indexed document. It's
"static" because it happens one time at the start of the test suite
and remains available and unchanged for any read-only operation.

This is required because it takes time for a document to be indexed, so
we have to poll the API until the indexing is finished in order to
continue. It's better to do this once so that we only wait once,
not multiple times throughout the test suite.