### PR TITLE
Fix signed search keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install the gem, execute:
 gem install swiftype-app-search
 ```
 
-Or place `gem 'swiftype-app-search', '~> 0.4.3` in your `Gemfile` and run `bundle install`.
+Or place `gem 'swiftype-app-search', '~> 0.4.4` in your `Gemfile` and run `bundle install`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install the gem, execute:
 gem install swiftype-app-search
 ```
 
-Or place `gem 'swiftype-app-search', '~> 0.4.2` in your `Gemfile` and run `bundle install`.
+Or place `gem 'swiftype-app-search', '~> 0.4.3` in your `Gemfile` and run `bundle install`.
 
 ## Usage
 

--- a/lib/swiftype-app-search/client.rb
+++ b/lib/swiftype-app-search/client.rb
@@ -43,7 +43,6 @@ module SwiftypeAppSearch
         #
         # @return [String] the JWT to use for authentication
         def create_signed_search_key(api_key, api_key_name, options = {})
-          raise 'Must create signed search key with an API Key, cannot use a Search Key' unless api_key.start_with?('api')
           payload = Utils.symbolize_keys(options).merge(:api_key_name => api_key_name)
           JWT.encode(payload, api_key, ALGORITHM)
         end

--- a/lib/swiftype-app-search/version.rb
+++ b/lib/swiftype-app-search/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeAppSearch
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/lib/swiftype-app-search/version.rb
+++ b/lib/swiftype-app-search/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeAppSearch
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,6 +37,26 @@ describe SwiftypeAppSearch::Client do
     @static_client.destroy_engine(@static_engine_name)
   end
 
+  describe '#create_signed_search_key' do
+    let(:key) { 'private-xxxxxxxxxxxxxxxxxxxx' }
+    let(:api_key_name) { 'private-key' }
+    let(:enforced_options) do
+      {
+        'query' => 'cat'
+      }
+    end
+
+    subject do
+      SwiftypeAppSearch::Client.create_signed_search_key(key, api_key_name, enforced_options)
+    end
+
+    it 'should build a valid jwt' do
+      decoded_token = JWT.decode subject, key, true, { algorithm: 'HS256' }
+      expect(decoded_token[0]['api_key_name']).to eq(api_key_name)
+      expect(decoded_token[0]['query']).to eq('cat')
+    end
+  end
+
   describe 'Requests' do
     it 'should include client name and version in headers' do
       stub_request(:any, "#{client_options[:host_identifier]}.api.swiftype.com/api/as/v1/engines")


### PR DESCRIPTION
Fixes #37

This method was explicitly requiring key values to start with
'api', which is legacy syntax. The current prefix is 'private',
which this library was rejecting.

Rather than fixing this check, I removed it completely. We will
rely on the server to validate the key that was used.