### PR TITLE
Enable calling #each on search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ search_fields = { :title => {} }
 result_fields = { :title => { :raw => {} } }
 options = { :search_fields => search_fields, :result_fields => result_fields }
 
-client.search(engine_name, query, options)
+client.search(engine_name, query, options).map { |document| puts document['title']['raw'] }
 ```
 
 #### Multi-Search
@@ -186,7 +186,7 @@ queries = [{
   :options => { :search_fields => { :body => {} }}
 }]
 
-client.multi_search(engine_name, queries)
+client.multi_search(engine_name, queries).flat_map { |document| puts document['title']['raw'] }
 ```
 
 #### Query Suggestion

--- a/lib/swiftype-app-search/client/search.rb
+++ b/lib/swiftype-app-search/client/search.rb
@@ -27,9 +27,11 @@ module SwiftypeAppSearch
           options = search[:options] || {}
           Utils.symbolize_keys(options).merge(:query => query)
         end
-        request(:post, "engines/#{engine_name}/multi_search", {
+        request(
+          :post,
+          "engines/#{engine_name}/multi_search",
           queries: params
-        })
+        ).map { |result_set| ResultResponse.new(result_set) }
       end
     end
   end

--- a/lib/swiftype-app-search/result_response.rb
+++ b/lib/swiftype-app-search/result_response.rb
@@ -1,0 +1,35 @@
+# Forwards Ruby Enumerable methods to the :results key of the response for
+# endpoints that contain pagination while still maintaining Hash functionality
+# Methods like #[] and #[]= will still fall back to Hash-like behavior
+
+class SwiftypeAppSearch::ResultResponse
+  include Enumerable
+
+  def initialize(response_json)
+    @response_json = response_json
+
+    if @response_json.is_a?(Hash) && @response_json.key?('errors')
+      raise SwiftypeAppSearch::ClientException, @response_json
+    end
+  end
+
+  attr_reader :response_json
+  alias_method :json, :response_json
+
+  def results
+    return @results if defined?(@results)
+    @results = @response_json['results'] if @response_json.is_a?(Hash)
+  end
+
+  def meta
+    @meta ||= @response_json['meta'].to_h
+  end
+
+  def each
+    results.nil? ? @response_json.each(&Proc.new) : results.each(&Proc.new)
+  end
+
+  def method_missing(symbol, *args, &block)
+    @response_json.send(symbol, *args, &block)
+  end
+end

--- a/lib/swiftype-app-search/version.rb
+++ b/lib/swiftype-app-search/version.rb
@@ -1,3 +1,3 @@
 module SwiftypeAppSearch
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -133,7 +133,7 @@ describe SwiftypeAppSearch::Client do
       subject { client.index_documents(engine_name, documents) }
 
       it 'should return an array of document status hashes' do
-        expect(subject).to match(
+        expect(subject.json).to match(
           [
             { 'id' => anything, 'errors' => [] },
             { 'id' => second_document_id, 'errors' => [] }
@@ -145,7 +145,7 @@ describe SwiftypeAppSearch::Client do
         let(:second_document) { { 'id' => 'too long' * 100 } }
 
         it 'should return respective errors in an array of document processing hashes' do
-          expect(subject).to match(
+          expect(subject.json).to match(
             [
               { 'id' => anything, 'errors' => [] },
               { 'id' => anything, 'errors' => ['Invalid field type: id must be less than 800 characters'] },
@@ -179,7 +179,7 @@ describe SwiftypeAppSearch::Client do
       # the request responded with the correct 'id', even though
       # the 'errors' object likely contains errors.
       it 'should update existing documents' do
-        expect(subject).to match(['id' => second_document_id, 'errors' => anything])
+        expect(subject.json).to match(['id' => second_document_id, 'errors' => anything])
       end
     end
 
@@ -241,7 +241,7 @@ describe SwiftypeAppSearch::Client do
       let(:options) { { 'page' => { 'size' => 2 } } }
 
       it 'should execute a search query' do
-        expect(subject).to match(
+        expect(subject.json).to match(
           'meta' => anything,
           'results' => [anything, anything]
         )
@@ -261,7 +261,7 @@ describe SwiftypeAppSearch::Client do
 
         it 'should execute a multi search query' do
           response = subject
-          expect(response).to match(
+          expect(response.map(&:json)).to match(
             [
               {
                 'meta' => anything,
@@ -286,7 +286,7 @@ describe SwiftypeAppSearch::Client do
 
         it 'should execute a multi search query' do
           response = subject
-          expect(response).to match(
+          expect(response.map(&:json)).to match(
             [
               {
                 'meta' => anything,
@@ -333,7 +333,7 @@ describe SwiftypeAppSearch::Client do
         subject { @static_client.query_suggestion(@static_engine_name, query, options) }
 
         it 'should request query suggestions' do
-          expect(subject).to match(
+          expect(subject.json).to match(
             'meta' => anything,
             'results' => anything
           )
@@ -344,7 +344,7 @@ describe SwiftypeAppSearch::Client do
         subject { @static_client.query_suggestion(@static_engine_name, query) }
 
         it 'should request query suggestions' do
-          expect(subject).to match(
+          expect(subject.json).to match(
             'meta' => anything,
             'results' => anything
           )
@@ -384,7 +384,7 @@ describe SwiftypeAppSearch::Client do
       subject { client.show_settings(engine_name) }
 
       it 'should return default settings' do
-        expect(subject).to match(default_settings)
+        expect(subject.json).to match(default_settings)
       end
     end
 
@@ -396,7 +396,7 @@ describe SwiftypeAppSearch::Client do
       end
 
       it 'should update search settings' do
-        expect(subject).to match(updated_settings)
+        expect(subject.json).to match(updated_settings)
       end
     end
 
@@ -409,7 +409,7 @@ describe SwiftypeAppSearch::Client do
       end
 
       it 'should reset search settings' do
-        expect(subject).to match(default_settings)
+        expect(subject.json).to match(default_settings)
       end
     end
   end
@@ -429,12 +429,12 @@ describe SwiftypeAppSearch::Client do
       it 'should accept an optional language parameter' do
         expect { client.get_engine(engine_name) }.to raise_error(SwiftypeAppSearch::NonExistentRecord)
         client.create_engine(engine_name, 'da')
-        expect(client.get_engine(engine_name)).to match('name' => anything, 'type' => anything, 'language' => 'da')
+        expect(client.get_engine(engine_name).json).to match('name' => anything, 'type' => anything, 'language' => 'da')
       end
 
       it 'should return an engine object' do
         engine = client.create_engine(engine_name)
-        expect(engine).to be_kind_of(Hash)
+        expect(engine).to be_kind_of(SwiftypeAppSearch::ResultResponse)
         expect(engine['name']).to eq(engine_name)
       end
 

--- a/spec/result_response_spec.rb
+++ b/spec/result_response_spec.rb
@@ -1,0 +1,63 @@
+require 'config_helper'
+
+describe SwiftypeAppSearch::ResultResponse do
+  subject(:response) { described_class.new(response_json) }
+  describe '#each' do
+    context 'when the response contains "results"' do
+      let(:response_json) do
+        {
+          'results' => [
+            {
+              'id' => 'id-01'
+            }
+          ]
+        }
+      end
+
+      it 'should enumerate the results' do
+        expect(response.map { |r| r['id'] }).to contain_exactly('id-01')
+      end
+    end
+
+    context 'when the response does not contain "results"' do
+      let(:response_json) do
+        {
+          'id' => 'engine-01',
+          'name' => 'new-engine'
+        }
+      end
+
+      it 'should enumerate the response JSON' do
+        expect(response.map { |_, v| v }).to match_array(response_json.values)
+      end
+    end
+  end
+
+  describe '#meta' do
+    context 'when the response contains "meta"' do
+      let(:response_json) do
+        {
+          'meta' => {
+            'page' => {
+              'current' => 1
+            }
+          }
+        }
+      end
+
+      it 'should return "meta"' do
+        expect(response.meta).to have_key('page')
+      end
+    end
+
+    context 'when the response does not contain "meta"' do
+      let(:response_json) do
+        { 'name' => 'engine-name' }
+      end
+
+      it 'should return an empty Hash' do
+        expect(response.meta).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows calling Enumerable methods on responses and transparently
forwarding the method to the results array if it exists in the response.

Also adds a convenience method `Client#last_response` that will return the
raw unaltered Hash format of the last response.

It might be also a good idea to implement some additional methods on `ResultResponse`, like `#==`, which might clean up specs, but I don't expect anyone to use the client that way.